### PR TITLE
chore: update mods.toml for client-side only

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -13,6 +13,7 @@ authors="${author}, LambdAurora"
 description="${description}"
 logoFile="assets/${namespace}/textures/mod_logo.png"
 displayURL = "https://github.com/${github}/${name}/"
+displayTest="IGNORE_ALL_VERSION"
 
 [[mixins]]
 config = "mixins.${id}.json"


### PR DESCRIPTION
### Issue
SodiumDynamicLights causes the sidedness checker in Forge to throw a red X if the mod is only installed client-side, which is a problem when the mod isn't needed on the server (nor works if on the server).

### Solution
This may be a bit of a bandaid, but the solution here is to use Forge's `displayTest` parameter within mods.toml to ignore any X flagging. This is documented here: https://docs.minecraftforge.net/en/latest/concepts/sides/#writing-one-sided-mods